### PR TITLE
updating entrypoint map2model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 versions here coincide with releases on pypi.
 
 ## [master](https://github.com/openschemas/openschemas-python/tree/master)
+ - bug in entrypoint script for map2model (0.0.13)
  - tweaks to specification.yml for live testing in specifications repo (0.0.12)
  - validation model, including default for a specification, and dummy (0.0.11)
  - start to spinx documentation, including start to usage docs

--- a/openschemas/cli/map2model/__init__.py
+++ b/openschemas/cli/map2model/__init__.py
@@ -44,7 +44,7 @@ def main():
 
     spec_parser = main(folder=args.specs,
                        output=args.outfolder,
-                       config=args.config,
+                       config_yml=args.config,
                        template=args.template,
                        repo=args.repo)
 

--- a/openschemas/version.py
+++ b/openschemas/version.py
@@ -2,7 +2,7 @@
 # See the LICENSE in the main repository at:
 #    https://www.github.com/openschemas/openschemas-python
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'openschemas'


### PR DESCRIPTION
There is a dual bug that the schema-builder is using an old entrypoint (and needs to be rebuilt here) AND the entrypoint to map2model (the console_script) wasn't updated to use the config_yml variable (instead of config) as an argument to main. This will close #16, which was missing the output folder because the wrong entrypoing script was being used!